### PR TITLE
Adjust relationship typing in models

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from datetime import date
-from typing import Optional
+from typing import List, Optional
 
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -16,7 +14,7 @@ class User(SQLModel, table=True):
     daily_goal_minutes: int = Field(default=10)
     preferred_language: str = Field(default="ru")
 
-    progress: list[TopicProgress] = Relationship(back_populates="user")
+    progress: List["TopicProgress"] = Relationship(back_populates="user")
 
 
 class TopicProgress(SQLModel, table=True):
@@ -28,4 +26,4 @@ class TopicProgress(SQLModel, table=True):
     best_score: float = Field(default=0.0)
     xp_earned: int = Field(default=0)
 
-    user: User = Relationship(back_populates="progress")
+    user: "User" = Relationship(back_populates="progress")


### PR DESCRIPTION
## Summary
- import typing.List in models to support relationship annotations
- annotate User.progress with List["TopicProgress"] and ensure reciprocal string reference
- drop __future__ annotations import so SQLModel resolves relationships correctly

## Testing
- python -m uvicorn app.main:app --reload

------
https://chatgpt.com/codex/tasks/task_e_68c8733f3f24832eb6edcd4a9129122c