### PR TITLE
Configure Vite for relative asset URLs

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- add a Vite base configuration so build outputs use relative asset URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c1d05f08832e8e8d860e9f6c08f8