### PR TITLE
Use HashRouter for GitHub Pages navigation

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 
 import App from './App';
 import './index.css';
@@ -9,12 +9,12 @@ import { ThemeProvider } from './context/ThemeContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <ThemeProvider>
         <ProgressProvider>
           <App />
         </ProgressProvider>
       </ThemeProvider>
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace BrowserRouter with HashRouter so client-side navigation stays under the GitHub Pages path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c4817d70832eb474b3d8f1e89bfa