### PR TITLE
Fix repeated topic loading in practice page

### DIFF
--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -10,7 +10,8 @@ import { Hint, TaskPayload, TopicDetail } from '../types';
 const EXAM_DURATION = 180;
 
 function useQuery() {
-  return new URLSearchParams(useLocation().search);
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
 }
 
 export default function PracticePage() {


### PR DESCRIPTION
## Summary
- memoize the query-string parser on the practice page so topic loading only runs when the URL actually changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cacc53bc832e90059ec065d5f912