### PR TITLE
Remove future annotations import from spec

### DIFF
--- a/desktop_app/app.spec
+++ b/desktop_app/app.spec
@@ -1,7 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_submodules


### PR DESCRIPTION
## Summary
- remove the __future__ annotations import from desktop_app/app.spec

## Testing
- pyinstaller desktop_app/app.spec *(fails: NameError: name '__file__' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d19558a520832e8651c8d94acb1c25